### PR TITLE
Return the width of aligned labels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,10 @@
 =======
 History
 =======
-
+2024.7.21 -- Return the width of aligned labels
+    * The align_labels procedure now returns the width of the labels. This is useful for
+      laying out indented widgets.
+      
 2024.5.1 -- Enhancement to ScrolledColumns
     * Added optional separator columns for dividing sections of the table.
       

--- a/seamm_widgets/labeled_widget.py
+++ b/seamm_widgets/labeled_widget.py
@@ -40,10 +40,10 @@ options = {
 }
 
 
-def align_labels(widgets, sticky=None):
+def align_labels(widgets, sticky=tk.E):
     """Align the labels of a given list of widgets"""
-    if len(widgets) <= 1:
-        return
+    if len(widgets) == 0:
+        return 0
 
     widgets[0].update_idletasks()
 
@@ -56,10 +56,13 @@ def align_labels(widgets, sticky=None):
 
     # Adjust the margins for the labels such that the child sites and
     # labels line up.
-    for widget in widgets:
-        if sticky is not None:
-            widget.label.grid(sticky=sticky)
-        widget.grid_columnconfigure(0, minsize=max_width)
+    if len(widgets) > 1:
+        for widget in widgets:
+            if sticky is not None:
+                widget.label.grid(sticky=sticky)
+            widget.grid_columnconfigure(0, minsize=max_width)
+
+    return max_width
 
 
 class LabeledWidget(ttk.Frame):


### PR DESCRIPTION
    * The align_labels procedure now returns the width of the labels. This is useful for laying out indented widgets.